### PR TITLE
Update jf-aap dependency version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ ark-serialize = { version = "0.3.0", features = ["derive"] }
 bincode = "1.3.3"
 commit = { git = "ssh://git@github.com/SpectrumXYZ/commit.git", rev = "f48cd52c59755eade0605111826eef3df6abdcf8" }
 itertools = "0.10.1"
-jf-aap = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", branch = "keyao-tag" }
+jf-aap = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "8c32d8df3faf511e54ad89fa51627837ebcd8f20" }
 serde = { version = "1.0", features = ["derive"] }
 serde_with = "1.10.0"
 snafu = { version = "0.6.10", features = ["backtraces"] }


### PR DESCRIPTION
Depends on: [SpectrumXYZ/jellyfish-apps#89](https://github.com/SpectrumXYZ/jellyfish-apps/pull/89).