### PR TITLE
Updated jf-cap dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2018"
 [dependencies]
 ark-serialize = { version = "0.3.0", features = ["derive"] }
 bincode = "1.3.3"
-commit = { git = "ssh://git@github.com/SpectrumXYZ/commit.git", rev = "f48cd52c59755eade0605111826eef3df6abdcf8" }
+commit = { git = "ssh://git@github.com/EspressoSystems/commit.git", rev = "f48cd52c59755eade0605111826eef3df6abdcf8" }
 itertools = "0.10.1"
-jf-cap = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/cap.git", rev = "cba0b2fc682606b0a118b320d41f718c525b4192" }
+jf-cap = { features=["std"], git = "ssh://git@github.com/EspressoSystems/cap.git", rev = "16ad157f96d2102d59206df0106fb341302180d3" }
 serde = { version = "1.0", features = ["derive"] }
 serde_with = "1.10.0"
 snafu = { version = "0.6.10", features = ["backtraces"] }


### PR DESCRIPTION
Changelog: 
- https://github.com/EspressoSystems/cap/commit/c969d2bf741982b5fc5eeb1769f9e2ced84e87e0
- https://github.com/EspressoSystems/cap/commit/16ad157f96d2102d59206df0106fb341302180d3

Diff: https://github.com/EspressoSystems/cap/compare/cba0b2fc682606b0a118b320d41f718c525b4192...16ad157f96d2102d59206df0106fb341302180d3

Part of https://github.com/EspressoSystems/cape/pull/603
- [x] `cat Cargo.lock | grep Spectrum` returned no entries