### PR TITLE
Fix bug in `best_fit_key`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: default
-          toolchain: stable
+          toolchain: "1.58"
           override: true
           default: true
           components: rustfmt, clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "key-set"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2018"
 license = "GPL-3.0-or-later"
 


### PR DESCRIPTION
Previously, it could sometimes return a key with `inputs < min_inputs`
or `outputs < min_outputs`, which is not allowed.