### PR TITLE
Pin to cap release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ ark-serialize = { version = "0.3.0", features = ["derive"] }
 bincode = "1.3.3"
 commit = { git = "https://github.com/EspressoSystems/commit.git", tag = "0.1.0" }
 itertools = "0.10.1"
-jf-cap = { features=["std"], git = "https://github.com/EspressoSystems/cap.git" }
+jf-cap = { features=["std"], git = "https://github.com/EspressoSystems/cap.git", tag = "0.0.2" }
 serde = { version = "1.0", features = ["derive"] }
 serde_with = "1.10.0"
 snafu = { version = "0.7", features = ["backtraces"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "key-set"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2018"
 license = "GPL-3.0-or-later"
 


### PR DESCRIPTION
Need to point all Seahorse Dependencies at same CAP version